### PR TITLE
feat: description suggested by Claude.ai!

### DIFF
--- a/web/app/habit/components/NewUser.tsx
+++ b/web/app/habit/components/NewUser.tsx
@@ -1,29 +1,39 @@
 'use client';
 
 import { SubTitle } from '@/components/SubTitle/SubTitle';
+import { randomChoice } from '@/utils/content';
 import { Button } from '@nextui-org/button';
 import { useRouter } from 'next/navigation';
+import { useMemo } from 'react';
 
 export default function NewUser() {
   const { push } = useRouter();
+
+  const content = useMemo(() => {
+    return randomChoice([
+      `No habits? No glory. Pick a challenge or create your own – your wallet's waiting.`,
+      'Your USDC is getting bored. Create a habit or join a challenge – put it to work!',
+      `Idle hands (and USDC) are the devil's playground. Start a habit or join the action!`,
+      `No habits, no bragging rights. Start your own or join the fray – your USDC is itching to play.`,
+      `Empty habit list = missed opportunities. Craft your challenge or join one – let's turn that USDC into motivation fuel.`,
+    ]);
+  }, []);
 
   return (
     <main className="container mx-4 flex flex-col items-center px-4 text-center">
       <div className="flex w-full flex-col items-center justify-center">
         <SubTitle text="Welcome to Atomic" />
 
-        <p className="mx-4 pt-8 font-nunito text-sm">
-          To start your Atomic journey, you can join a challenge or create a new one.
-        </p>
+        <p className="mx-4 pt-8 font-nunito text-sm">{content}</p>
 
         {/* two buttons  */}
         <div className="flex w-full gap-2 pt-8">
-          <Button className="w-1/2 no-underline" onClick={() => push('/habit/create')}>
+          <Button className="min-h-12 w-1/2 no-underline" onClick={() => push('/habit/create')}>
             <div className="my-4 rounded-lg p-4">Create</div>
           </Button>
           <Button
             color="primary"
-            className="w-1/2 no-underline"
+            className="min-h-12 w-1/2 no-underline"
             onClick={() => push('/habit/list')}
           >
             <div className="my-4 rounded-lg p-4">Explore</div>

--- a/web/app/habit/components/Onboard.tsx
+++ b/web/app/habit/components/Onboard.tsx
@@ -15,11 +15,11 @@ export default function Onboard() {
 
   const content = useMemo(() => {
     return randomChoice([
-      'Ready to put your money where your habits are? Connect now!',
+      'Ready to put your money where your habits are? Start now!',
       'No pain, no gain... no check-in, no coin.',
-      'Stakes are high, rewards are higher. Connect and commit.',
+      'Stakes are high, rewards are higher. Start and commit.',
       'Your habits or your USDC – which will last longer? Join to find out.',
-      'Warning: Connection may lead to life improvement and potential profits.',
+      'Warning: Participation may lead to life improvement and potential profits.',
     ]);
   }, []);
 

--- a/web/app/habit/components/Onboard.tsx
+++ b/web/app/habit/components/Onboard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ConnectButton } from '@/components/Connect/ConnectButton';
 import { SignInAndRegister } from '@/components/Connect/SignInAndRegister';
 import { SubTitle } from '@/components/SubTitle/SubTitle';
-import { Button } from '@nextui-org/button';
+import { randomChoice } from '@/utils/content';
 import { useRouter } from 'next/navigation';
+import { useMemo } from 'react';
 
 /**
  * For first time visitor (not-logged in) to the app!
@@ -13,12 +13,22 @@ import { useRouter } from 'next/navigation';
 export default function Onboard() {
   const { push } = useRouter();
 
+  const content = useMemo(() => {
+    return randomChoice([
+      'Ready to put your money where your habits are? Connect now!',
+      'No pain, no gain... no check-in, no coin.',
+      'Stakes are high, rewards are higher. Connect and commit.',
+      'Your habits or your USDC – which will last longer? Join to find out.',
+      'Warning: Connection may lead to life improvement and potential profits.',
+    ]);
+  }, []);
+
   return (
     <main className="container mx-6 flex flex-col items-center px-4 text-center">
       <div className="flex w-full flex-col items-center justify-center">
         <SubTitle text="Welcome to Atomic" />
 
-        <p className="mx-4 pb-4 pt-12 font-nunito text-sm">Stake, commit, and track your habits.</p>
+        <p className="mx-6 pb-4 pt-12 font-nunito text-sm">{content}</p>
 
         <SignInAndRegister />
       </div>

--- a/web/app/habit/stake/components/JoinedPopup.tsx
+++ b/web/app/habit/stake/components/JoinedPopup.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import { Challenge } from '@/types';
 import PopupWindow from '@/components/PopupWindow/PopupWindow';
+import { randomChoice } from '@/utils/content';
 
 type JoinedPopupProps = {
   challenge: Challenge;
@@ -14,14 +15,27 @@ type JoinedPopupProps = {
 function JoinedPopup({ challenge, onClose, onCheckInPageClick }: JoinedPopupProps) {
   const title = "You've Successfully\nJoined the Challenge!";
 
+  const started = useMemo(() => {
+    return challenge.startTimestamp < moment().unix();
+  }, [challenge.startTimestamp]);
+
+  const additionalText = useMemo(() => {
+    return randomChoice([
+      `You're in. Now don't let your USDC become someone else's bonus.`,
+      `Challenge accepted. Your wallet's fate is in your hands now.`,
+      `Game on. Your USDC's either motivating you or motivating others soon.`,
+      `You've stepped into the arena. Time to turn those USDC into trophies.`,
+    ]);
+  }, []);
+
   const content = (
-    <div>
-      <p>Challenge starts from</p>
-      <p>
-        <strong>
-          {moment.unix(Number(challenge.startTimestamp.toString())).format('MMMM Do')}
-        </strong>
-      </p>
+    <div className="mx-4 font-nunito">
+      {started ? (
+        <p>Challenge ends {moment.unix(challenge.endTimestamp).fromNow()}!</p>
+      ) : (
+        <p>Challenge starts {moment.unix(challenge.startTimestamp).fromNow()}!</p>
+      )}
+      <div className="mt-8 text-sm italic">{additionalText}</div>
     </div>
   );
 

--- a/web/app/habit/stake/components/stakeContent.tsx
+++ b/web/app/habit/stake/components/stakeContent.tsx
@@ -23,7 +23,6 @@ import DepositPopup from './DepositPopup';
 import { Button } from '@nextui-org/button';
 import useUserStatus from '@/hooks/useUserStatus';
 import { Environment, getCurrentEnvironment } from '@/store/environment';
-import usePasskeyConnection from '@/hooks/usePasskeyConnection';
 import { useAllChallenges } from '@/providers/ChallengesProvider';
 import { Checkbox } from '@nextui-org/react';
 import { SubTitle } from '@/components/SubTitle/SubTitle';
@@ -36,7 +35,6 @@ export default function StakeChallenge() {
 
   const { challengeId } = useParams<{ challengeId: string }>();
   const { address } = useAccount();
-  const { login, isPending: connecting, signedInBefore, register } = usePasskeyConnection();
 
   const searchParams = useSearchParams();
   const attachedCode = searchParams.get('code') ?? '';

--- a/web/app/profile/components/NotConnected.tsx
+++ b/web/app/profile/components/NotConnected.tsx
@@ -5,11 +5,11 @@ import { SignInAndRegister } from '@/components/Connect/SignInAndRegister';
 export function NotConnected() {
   const content = useMemo(() => {
     return randomChoice([
-      'Your financial fate is sealed here. Connect to peek.',
-      "See if you are winning or contributing to others' winnings. Connect.",
-      `Your wallet's journey is documented here. Connect to track it.`,
-      'Your habit history is calling. Connect to answer.',
-      'Wallet fatter or lighter? Connect for the truth.',
+      'Your financial fate is sealed here. Sign in to peek.',
+      "See if you are winning or contributing to others' winnings. ",
+      `Your wallet's journey is documented here. Sign in to track it.`,
+      'Your habit history is calling. Sign in to answer.',
+      'Wallet fatter or lighter? Sign in for the truth.',
     ]);
   }, []);
 

--- a/web/app/profile/components/NotConnected.tsx
+++ b/web/app/profile/components/NotConnected.tsx
@@ -1,0 +1,22 @@
+import { randomChoice } from '@/utils/content';
+import { useMemo } from 'react';
+import { SignInAndRegister } from '@/components/Connect/SignInAndRegister';
+
+export function NotConnected() {
+  const content = useMemo(() => {
+    return randomChoice([
+      'Your financial fate is sealed here. Connect to peek.',
+      "See if you are winning or contributing to others' winnings. Connect.",
+      `Your wallet's journey is documented here. Connect to track it.`,
+      'Your habit history is calling. Connect to answer.',
+      'Wallet fatter or lighter? Connect for the truth.',
+    ]);
+  }, []);
+
+  return (
+    <div className="mt-12 flex flex-col items-center justify-center">
+      <div className="mx-6 text-center font-nunito text-sm">{content}</div>
+      <SignInAndRegister />
+    </div>
+  );
+}

--- a/web/app/profile/components/ProfileContent.tsx
+++ b/web/app/profile/components/ProfileContent.tsx
@@ -18,9 +18,8 @@ import { UserStatus } from '@/types';
 import { useState } from 'react';
 import DepositPopup from 'app/habit/stake/components/DepositPopup';
 import WithdrawPopup from './WithdrawPopup';
-import { ConnectButton } from '@/components/Connect/ConnectButton';
 import { SubTitle } from '@/components/SubTitle/SubTitle';
-import { SignInAndRegister } from '@/components/Connect/SignInAndRegister';
+import { NotConnected } from './NotConnected';
 
 export default function ProfileContent() {
   const { address, chainId } = useAccount();
@@ -78,10 +77,7 @@ export default function ProfileContent() {
         <SubTitle text="User Profile" />
 
         {address === undefined ? (
-          <div className="flex flex-col items-center justify-center">
-            <div className="my-4 pt-10 font-nunito text-sm">Connect to view your profile</div>
-            <SignInAndRegister />
-          </div>
+          <NotConnected />
         ) : (
           <>
             <div className="mt-12 w-full rounded-lg bg-slate-100 p-4 shadow-sm">

--- a/web/src/utils/content.ts
+++ b/web/src/utils/content.ts
@@ -1,0 +1,3 @@
+export function randomChoice<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}


### PR DESCRIPTION
## Copy change!

**this will merges into #156** 

3 個頁面有新的 description:
* onboard (第一次來，沒註冊過）
* newUser: 登入後發現沒有任何 challenge
* profile: 沒登入的用戶

分別隨機顯示不同的 text，引導用戶 login or explore ...etc

## Popup copy
* joined popup 如果挑戰已經開始，顯示到期日
* 加上一段斜體搞笑文字

## 範例
<img width="380" alt="Screenshot 2024-08-25 at 01 20 12" src="https://github.com/user-attachments/assets/af65fb60-b1b7-4ae7-8435-f8a30c7f8cdf">
<img width="394" alt="Screenshot 2024-08-25 at 01 20 46" src="https://github.com/user-attachments/assets/995f4a18-caf6-4956-b4bc-7e800e6ebc90">

