### PR TITLE
add leaderboard

### DIFF
--- a/web/app/api/on-chain/challenges/route.ts
+++ b/web/app/api/on-chain/challenges/route.ts
@@ -27,6 +27,7 @@ export async function GET(req: NextRequest): Promise<Response> {
             user {
               id
             }
+            totalCheckIns
           }
         }
         latestChallenge: challenges(first: 1, orderBy: id, orderDirection: desc) {

--- a/web/app/api/on-chain/utils/conversion.ts
+++ b/web/app/api/on-chain/utils/conversion.ts
@@ -33,7 +33,10 @@ export function transformChallenge(challenge: Challenge) {
   return {
     ...challenge,
     id: convertBytesToNumber(challenge.id).toString(),
-    joinedUsers: challenge.joinedUsers.map((user) => user.user.id),
+    joinedUsers: challenge.joinedUsers.map((user) => ({
+      id: user.user.id,
+      totalCheckIns: user.totalCheckIns,
+    })),
 
     winningStakePerUser: calculateWinningStakePerUser(
       BigInt(challenge.totalUsers),

--- a/web/app/api/on-chain/utils/types.ts
+++ b/web/app/api/on-chain/utils/types.ts
@@ -24,6 +24,7 @@ export type User = {
   user: {
     id: string;
   };
+  totalCheckIns: string;
 };
 
 export type LatestChallenge = {

--- a/web/app/habit/checkin/components/checkinRun.tsx
+++ b/web/app/habit/checkin/components/checkinRun.tsx
@@ -20,6 +20,7 @@ import { Button } from '@nextui-org/button';
 import InviteLink from 'app/habit/components/InviteLink';
 import { ConnectButton } from '@/components/Connect/ConnectButton';
 import { useUserChallenges } from '@/providers/UserChallengesProvider';
+import Leaderboard from 'app/habit/components/Leaderboard';
 
 const initFields: CheckInFields = {
   challengeId: 0,
@@ -152,6 +153,15 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
       ? cyclingData
       : workoutData;
 
+  // TODO: get user rankings from subgraph
+  const userRankings = [
+    { address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e", checkIns: 5 },
+    { address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", checkIns: 4 },
+    { address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0", checkIns: 3 },
+    { address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E", checkIns: 2 },
+    { address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30", checkIns: 1 },
+  ];
+
   return (
     <div className="flex h-screen w-full flex-col items-center px-4 text-center">
       {/* overview   */}
@@ -249,6 +259,14 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
             Connect with Strava
           </Button>
         ))}
+
+      {challenge && address && (
+        <Leaderboard 
+          userRankings={userRankings} 
+          address={address}
+          challenge={challenge} 
+        />
+      )}
 
       {isCheckinPopupOpen && (
         <CheckinPopup

--- a/web/app/habit/checkin/components/checkinRun.tsx
+++ b/web/app/habit/checkin/components/checkinRun.tsx
@@ -153,15 +153,6 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
       ? cyclingData
       : workoutData;
 
-  // TODO: get user rankings from subgraph
-  const userRankings = [
-    { address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e", checkIns: 5 },
-    { address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", checkIns: 4 },
-    { address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0", checkIns: 3 },
-    { address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E", checkIns: 2 },
-    { address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30", checkIns: 1 },
-  ];
-
   return (
     <div className="flex h-screen w-full flex-col items-center px-4 text-center">
       {/* overview   */}
@@ -262,7 +253,7 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
 
       {challenge && address && (
         <Leaderboard 
-          userRankings={userRankings} 
+          userRankings={challenge.joinedUsers} 
           address={address}
           challenge={challenge} 
         />

--- a/web/app/habit/components/Leaderboard.tsx
+++ b/web/app/habit/components/Leaderboard.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
-
-type User = {
-  address: string;
-  checkIns: number;
-}
+import { User } from '@/types';
 
 type LeaderboardProps = {
   userRankings: User[];
@@ -26,7 +22,7 @@ function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
         </TableHeader>
         <TableBody>
           {userRankings.map((user, index) => (
-            <TableRow key={user.address}>
+            <TableRow key={user.id}>
               <TableCell className={`font-bold ${
                 index === 0 ? 'text-yellow-500' :
                 index === 1 ? 'text-gray-400' :
@@ -36,13 +32,13 @@ function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
                 {index + 1}
               </TableCell>
               <TableCell className={`font-bold ${
-                user.address === address ? "bg-primary text-white rounded-lg" : ""
+                user.id === address ? "bg-primary text-white rounded-lg" : ""
               }`}>
-                {user.address === address
+                {user.id === address
                   ? "You"
-                  : `${user.address.slice(0, 4)}...${user.address.slice(-4)}`}
+                  : `${user.id.slice(0, 4)}...${user.id.slice(-4)}`}
               </TableCell>
-              <TableCell className='font-bold'>{user.checkIns} / {challenge.minimumCheckIns}</TableCell>
+              <TableCell className='font-bold'>{user.totalCheckIns} / {challenge.minimumCheckIns}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/web/app/habit/components/Leaderboard.tsx
+++ b/web/app/habit/components/Leaderboard.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
 import { User } from '@/types';
+import { ChallengeTypes } from '@/constants';
 
 type LeaderboardProps = {
   userRankings: User[];
   address: string;
   challenge: {
     minimumCheckIns: number;
+    type: ChallengeTypes;
   };
 }
 
 function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
   return (
     <div className="w-full max-w-md mt-8">
-      <div className="text-xl text-dark mb-5">Leaderboard</div>
+      <div className="text-xl text-dark mb-5">🏆Leaderboard</div> 
       <Table aria-label="Leaderboard">
         <TableHeader>
           <TableColumn className="text-center bg-white">Rank</TableColumn>
-          <TableColumn className="text-center bg-white">Address</TableColumn>
+          <TableColumn className="text-center bg-white">ID</TableColumn>
           <TableColumn className="text-center bg-white">Check-ins</TableColumn>
         </TableHeader>
         <TableBody>
@@ -29,16 +31,25 @@ function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
                 index === 2 ? 'text-amber-600' :
                 ''
               }`}>
-                {index + 1}
+                No. {index + 1}
               </TableCell>
-              <TableCell className={`font-bold ${
-                user.id === address ? "bg-primary text-white rounded-lg" : ""
-              }`}>
-                {user.id === address
-                  ? "You"
-                  : `${user.id.slice(0, 4)}...${user.id.slice(-4)}`}
+              <TableCell>
+                <div
+                  id="super-good-ball"
+                  className={`font-bold flex justify-center items-center ${
+                    user.id === address.toLocaleLowerCase() ? "bg-primary text-white" : "bg-dark text-white"
+                  }`}
+                  style={{
+                    borderRadius: '50%',
+                    height: '60px',
+                  }}
+                  >
+                  {user.id === address.toLocaleLowerCase()
+                    ? "You"
+                    : `${user.id.slice(2, 5)}`}
+                </div>
               </TableCell>
-              <TableCell className='font-bold'>{user.totalCheckIns} / {challenge.minimumCheckIns}</TableCell>
+              <TableCell className='font-bold'>{user.totalCheckIns} {challenge.type}s</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/web/app/habit/components/Leaderboard.tsx
+++ b/web/app/habit/components/Leaderboard.tsx
@@ -13,6 +13,8 @@ type LeaderboardProps = {
 }
 
 function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
+  const sortedUserRankings = [...userRankings].sort((a, b) => Number(b.totalCheckIns) - Number(a.totalCheckIns));
+
   return (
     <div className="w-full max-w-md mt-8">
       <div className="text-xl text-dark mb-5">🏆Leaderboard</div> 
@@ -23,7 +25,7 @@ function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
           <TableColumn className="text-center bg-white">Check-ins</TableColumn>
         </TableHeader>
         <TableBody>
-          {userRankings.map((user, index) => (
+          {sortedUserRankings.map((user, index) => (
             <TableRow key={user.id}>
               <TableCell className={`font-bold ${
                 index === 0 ? 'text-yellow-500' :

--- a/web/app/habit/components/Leaderboard.tsx
+++ b/web/app/habit/components/Leaderboard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
+
+type User = {
+  address: string;
+  checkIns: number;
+}
+
+type LeaderboardProps = {
+  userRankings: User[];
+  address: string;
+  challenge: {
+    minimumCheckIns: number;
+  };
+}
+
+function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
+  return (
+    <div className="w-full max-w-md mt-8">
+      <div className="text-xl text-dark mb-5">Leaderboard</div>
+      <Table aria-label="Leaderboard">
+        <TableHeader>
+          <TableColumn className="text-center bg-white">Rank</TableColumn>
+          <TableColumn className="text-center bg-white">Address</TableColumn>
+          <TableColumn className="text-center bg-white">Check-ins</TableColumn>
+        </TableHeader>
+        <TableBody>
+          {userRankings.map((user, index) => (
+            <TableRow key={user.address}>
+              <TableCell className={`font-bold ${
+                index === 0 ? 'text-yellow-500' :
+                index === 1 ? 'text-gray-400' :
+                index === 2 ? 'text-amber-600' :
+                ''
+              }`}>
+                {index + 1}
+              </TableCell>
+              <TableCell className={`font-bold ${
+                user.address === address ? "bg-primary text-white rounded-lg" : ""
+              }`}>
+                {user.address === address
+                  ? "You"
+                  : `${user.address.slice(0, 4)}...${user.address.slice(-4)}`}
+              </TableCell>
+              <TableCell className='font-bold'>{user.checkIns} / {challenge.minimumCheckIns}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/web/app/habit/stake/components/stakeContent.tsx
+++ b/web/app/habit/stake/components/stakeContent.tsx
@@ -8,7 +8,6 @@ import toast from 'react-hot-toast';
 import { formatUnits } from 'viem';
 import { useAccount, useBalance } from 'wagmi';
 import { Input } from '@nextui-org/input';
-import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
 import moment, { now } from 'moment';
 
 import { usdcAddr } from '@/constants';
@@ -30,6 +29,7 @@ import { logEvent } from '@/utils/gtag';
 import { useUserChallenges } from '@/providers/UserChallengesProvider';
 import useChallenge from '@/hooks/useChallenge';
 import { useUserStatus } from '@/hooks/useUserStatus';
+import Leaderboard from 'app/habit/components/Leaderboard';
 
 const isTestnet = getCurrentEnvironment() === Environment.testnet;
 
@@ -153,11 +153,11 @@ export default function StakeChallenge() {
 
   // TODO: get user rankings from subgraph
   const userRankings = [
-    { name: "Alice", checkIns: 5 },
-    { name: "Bob", checkIns: 4 },
-    { name: "Charlie", checkIns: 3 },
-    { name: "David", checkIns: 2 },
-    { name: "Eve", checkIns: 1 },
+    { address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e", checkIns: 5 },
+    { address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", checkIns: 4 },
+    { address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0", checkIns: 3 },
+    { address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E", checkIns: 2 },
+    { address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30", checkIns: 1 },
   ];
 
   return (
@@ -309,25 +309,11 @@ export default function StakeChallenge() {
         )}
 
         {challenge && (
-          <div className="w-full max-w-md mt-8">
-            <h3 className="text-xl font-bold mb-4">Leaderboard</h3>
-            <Table aria-label="Leaderboard">
-              <TableHeader>
-                <TableColumn className="text-center">RANK</TableColumn>
-                <TableColumn className="text-center">NAME</TableColumn>
-                <TableColumn className="text-center">CHECK-INS</TableColumn>
-              </TableHeader>
-              <TableBody>
-                {userRankings.map((user, index) => (
-                  <TableRow key={index}>
-                    <TableCell>{index + 1}</TableCell>
-                    <TableCell>{user.name}</TableCell>
-                    <TableCell>{user.checkIns} / {challenge.minimumCheckIns}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+          <Leaderboard 
+            userRankings={userRankings} 
+            address="0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
+            challenge={challenge} 
+          />
         )}
 
         {/**

--- a/web/app/habit/stake/components/stakeContent.tsx
+++ b/web/app/habit/stake/components/stakeContent.tsx
@@ -151,15 +151,6 @@ export default function StakeChallenge() {
     handleOpenInsufficientBalancePopup();
   };
 
-  // TODO: get user rankings from subgraph
-  const userRankings = [
-    { address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e", checkIns: 5 },
-    { address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", checkIns: 4 },
-    { address: "0xdD2FD4581271e230360230F9337D5c0430Bf44C0", checkIns: 3 },
-    { address: "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E", checkIns: 2 },
-    { address: "0x2546BcD3c84621e976D8185a91A922aE77ECEc30", checkIns: 1 },
-  ];
-
   return (
     <main className="flex h-screen flex-col items-center px-4 pb-12 text-center">
       <div className="flex max-w-96 flex-col items-center justify-center">
@@ -310,8 +301,8 @@ export default function StakeChallenge() {
 
         {challenge && (
           <Leaderboard 
-            userRankings={userRankings} 
-            address="0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"
+            userRankings={challenge.joinedUsers} 
+            address=""
             challenge={challenge} 
           />
         )}

--- a/web/app/habit/stake/components/stakeContent.tsx
+++ b/web/app/habit/stake/components/stakeContent.tsx
@@ -8,6 +8,7 @@ import toast from 'react-hot-toast';
 import { formatUnits } from 'viem';
 import { useAccount, useBalance } from 'wagmi';
 import { Input } from '@nextui-org/input';
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
 import moment, { now } from 'moment';
 
 import { usdcAddr } from '@/constants';
@@ -149,6 +150,15 @@ export default function StakeChallenge() {
     }
     handleOpenInsufficientBalancePopup();
   };
+
+  // TODO: get user rankings from subgraph
+  const userRankings = [
+    { name: "Alice", checkIns: 5 },
+    { name: "Bob", checkIns: 4 },
+    { name: "Charlie", checkIns: 3 },
+    { name: "David", checkIns: 2 },
+    { name: "Eve", checkIns: 1 },
+  ];
 
   return (
     <main className="flex h-screen flex-col items-center px-4 pb-12 text-center">
@@ -296,6 +306,28 @@ export default function StakeChallenge() {
               </Button>
             </div>
           )
+        )}
+
+        {challenge && (
+          <div className="w-full max-w-md mt-8">
+            <h3 className="text-xl font-bold mb-4">Leaderboard</h3>
+            <Table aria-label="Leaderboard">
+              <TableHeader>
+                <TableColumn className="text-center">RANK</TableColumn>
+                <TableColumn className="text-center">NAME</TableColumn>
+                <TableColumn className="text-center">CHECK-INS</TableColumn>
+              </TableHeader>
+              <TableBody>
+                {userRankings.map((user, index) => (
+                  <TableRow key={index}>
+                    <TableCell>{index + 1}</TableCell>
+                    <TableCell>{user.name}</TableCell>
+                    <TableCell>{user.checkIns} / {challenge.minimumCheckIns}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
 
         {/**

--- a/web/src/providers/ChallengesProvider.tsx
+++ b/web/src/providers/ChallengesProvider.tsx
@@ -74,6 +74,7 @@ export function AllChallengesProvider({ children }: AllChallengesProviderProps) 
             totalStaked: BigInt(challenge.totalStake),
             succeedClaimable: BigInt(challenge.winningStakePerUser),
             challengeStatus: challenge.status as ChallengeStatus,
+            joinedUsers: challenge.joinedUsers,
           }))
           .sort((a: ChallengeDetail, b: ChallengeDetail) =>
             a.startTimestamp > b.startTimestamp ? 1 : -1,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,6 +11,11 @@ export enum WorkoutVerifier {
   Strava = 'Strava',
 }
 
+export type User = {
+  id: string;
+  totalCheckIns: string;
+}
+
 // Raw data from the chain / subgraph
 export type ChallengeDetail = {
   id: number;
@@ -25,6 +30,7 @@ export type ChallengeDetail = {
   totalStaked: bigint;
   succeedClaimable: bigint;
   challengeStatus: ChallengeStatus;
+  joinedUsers: User[];
 };
 
 // Defined by us, off-chain


### PR DESCRIPTION
fix #166 

todo
- [x] finish ui
- [x] get data from subgraph
- [x] 調整 ui

最新版 ui
table header 的部分如果要拿掉滿麻煩的，以及我認爲有保留的必要，所以就還是保留～
<img width="335" alt="截圖 2024-09-07 上午12 46 16" src="https://github.com/user-attachments/assets/c7e1f0cc-5863-45b5-8c37-349cbb34d92a">

第二版 ui
<img width="337" alt="截圖 2024-09-05 下午8 33 50" src="https://github.com/user-attachments/assets/78463314-d28e-4886-898b-9bc12ed170c5">

初版 ui 
<img width="359" alt="截圖 2024-09-04 下午11 05 15" src="https://github.com/user-attachments/assets/5dd42293-2a3c-4b30-b261-116c449dd1e6">
