### PR TITLE
feat: time left and end time description

### DIFF
--- a/web/app/habit/checkin/components/ActivityCheckIn.tsx
+++ b/web/app/habit/checkin/components/ActivityCheckIn.tsx
@@ -255,7 +255,12 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
     <div className="flex h-screen w-full flex-col items-center px-4 text-center">
       {/* overview   */}
       <div className="my-4 w-full">
-        <ChallengePreview challenge={challenge} fullWidth checkedIn={challenge.checkedIn} />
+        <ChallengePreview
+          challenge={challenge}
+          fullWidth
+          checkedIn={challenge.checkedIn}
+          showHint={false}
+        />
       </div>
 
       {/* goal description */}

--- a/web/app/habit/components/ChallengeBox.tsx
+++ b/web/app/habit/components/ChallengeBox.tsx
@@ -1,10 +1,28 @@
 import { Challenge, ChallengeWithCheckIns } from '@/types';
-import { challengeToEmoji, getUserChallengeStatus } from '@/utils/challenges';
-import { formatDuration, getCountdownString } from '@/utils/timestamp';
+import { challengeToEmoji } from '@/utils/challenges';
+import { formatDuration, getChallengePeriodHint } from '@/utils/timestamp';
 import moment from 'moment';
 import { CircularProgress } from '@nextui-org/react';
 import { UserChallengeStatus } from '@/types';
 import { useMemo } from 'react';
+
+function TimeHint({
+  startTimestamp,
+  endTimestamp,
+  showHint = true,
+}: {
+  startTimestamp: number;
+  endTimestamp: number;
+  showHint?: boolean;
+}) {
+  const hint = getChallengePeriodHint(startTimestamp, endTimestamp);
+  return (
+    <p className="text-xs opacity-80">
+      {formatDuration(startTimestamp, endTimestamp)}
+      {showHint && <span className="pl-2 font-nunito text-xs opacity-80">{hint}</span>}
+    </p>
+  );
+}
 
 export function ChallengeBox({
   challenge,
@@ -20,9 +38,10 @@ export function ChallengeBox({
       <div className="flex w-full items-center justify-start no-underline">
         <div className="p-2 text-3xl"> {challengeToEmoji(challenge.type)} </div>
         <div className="flex flex-col items-start justify-start p-2 text-primary">
-          <p className="text-xs font-bold opacity-80">
-            {formatDuration(challenge.startTimestamp, challenge.endTimestamp)}
-          </p>
+          <TimeHint
+            startTimestamp={challenge.startTimestamp}
+            endTimestamp={challenge.endTimestamp}
+          />
           <p className="text-start text-sm font-bold">{challenge.name}</p>
           <p className="text-sm"> {challenge.participants} joined </p>
         </div>
@@ -51,9 +70,10 @@ export function ChallengeBoxFilled({
       <div className="flex w-full items-center justify-start no-underline">
         <div className="p-2 text-3xl"> {challengeToEmoji(challenge.type)} </div>
         <div className="flex flex-col items-start justify-start p-2">
-          <p className="text-xs opacity-80">
-            {formatDuration(challenge.startTimestamp, challenge.endTimestamp)}
-          </p>
+          <TimeHint
+            startTimestamp={challenge.startTimestamp}
+            endTimestamp={challenge.endTimestamp}
+          />
           <p className="text-start text-sm font-bold">{challenge.name}</p>
           <p className="text-sm"> {challenge.participants} joined </p>
         </div>
@@ -86,27 +106,18 @@ export function ChallengePreview({
   challenge,
   checkedIn,
   fullWidth,
+  showHint,
 }: {
   challenge: ChallengeWithCheckIns;
   checkedIn: number;
   fullWidth?: boolean;
+  showHint?: boolean;
 }) {
   const userChallengeStatus = challenge.status;
 
   let percentage = (checkedIn * 100) / challenge.minimumCheckIns;
 
   const claimable = userChallengeStatus === UserChallengeStatus.Claimable;
-
-  const started = challenge.startTimestamp < moment().unix();
-  const isPast = challenge.endTimestamp < moment().unix();
-
-  const timeLeftOrStartTime = started
-    ? isPast
-      ? 'Ended'
-      : `${getCountdownString(challenge.endTimestamp, true)} left`
-    : `Starts in ${getCountdownString(challenge.startTimestamp, true)}`;
-
-  console.log('timeLeftOrStartTime', timeLeftOrStartTime)
 
   const customCss = useMemo(() => {
     if (userChallengeStatus === UserChallengeStatus.Failed) {
@@ -132,9 +143,11 @@ export function ChallengePreview({
       <div className="flex w-full items-center justify-start no-underline">
         <div className="p-2 text-3xl"> {challengeToEmoji(challenge.type)} </div>
         <div className="flex flex-col items-start justify-start p-2">
-          <p className="text-xs opacity-80">
-            {formatDuration(challenge.startTimestamp, challenge.endTimestamp)}  ({timeLeftOrStartTime})
-          </p>
+          <TimeHint
+            startTimestamp={challenge.startTimestamp}
+            endTimestamp={challenge.endTimestamp}
+            showHint={showHint}
+          />
           <p className="text-start text-sm font-bold">{challenge.name}</p>
           <p className="text-xs">
             {' '}

--- a/web/app/habit/components/ChallengeBox.tsx
+++ b/web/app/habit/components/ChallengeBox.tsx
@@ -1,6 +1,6 @@
 import { Challenge, ChallengeWithCheckIns } from '@/types';
 import { challengeToEmoji, getUserChallengeStatus } from '@/utils/challenges';
-import { formatDuration } from '@/utils/timestamp';
+import { formatDuration, getCountdownString } from '@/utils/timestamp';
 import moment from 'moment';
 import { CircularProgress } from '@nextui-org/react';
 import { UserChallengeStatus } from '@/types';
@@ -42,7 +42,6 @@ export function ChallengeBoxFilled({
   fullWidth?: boolean;
 }) {
   const isPast = challenge.endTimestamp < moment().unix();
-
   return (
     <div
       className={`wrapped-filled bg-primary p-2 ${isPast ? 'opacity-50' : ''} ${
@@ -98,6 +97,17 @@ export function ChallengePreview({
 
   const claimable = userChallengeStatus === UserChallengeStatus.Claimable;
 
+  const started = challenge.startTimestamp < moment().unix();
+  const isPast = challenge.endTimestamp < moment().unix();
+
+  const timeLeftOrStartTime = started
+    ? isPast
+      ? 'Ended'
+      : `${getCountdownString(challenge.endTimestamp, true)} left`
+    : `Starts in ${getCountdownString(challenge.startTimestamp, true)}`;
+
+  console.log('timeLeftOrStartTime', timeLeftOrStartTime)
+
   const customCss = useMemo(() => {
     if (userChallengeStatus === UserChallengeStatus.Failed) {
       return 'bg-failed';
@@ -123,7 +133,7 @@ export function ChallengePreview({
         <div className="p-2 text-3xl"> {challengeToEmoji(challenge.type)} </div>
         <div className="flex flex-col items-start justify-start p-2">
           <p className="text-xs opacity-80">
-            {formatDuration(challenge.startTimestamp, challenge.endTimestamp)}
+            {formatDuration(challenge.startTimestamp, challenge.endTimestamp)}  ({timeLeftOrStartTime})
           </p>
           <p className="text-start text-sm font-bold">{challenge.name}</p>
           <p className="text-xs">

--- a/web/app/habit/components/UserDashboard.tsx
+++ b/web/app/habit/components/UserDashboard.tsx
@@ -26,7 +26,9 @@ export default function Dashboard({ onGoingChallenges, totalChallengeCount }: Da
 
       {onGoingChallenges.length == 0 && (
         <div className="flex flex-col items-center justify-center">
-          <p className="m-4 font-nunito text-base text-center">No on going challenges, try joining one!</p>
+          <p className="m-4 text-center font-nunito text-base">
+            No on going challenges, try joining one!
+          </p>
         </div>
       )}
 

--- a/web/app/habit/create/components/step1.tsx
+++ b/web/app/habit/create/components/step1.tsx
@@ -9,6 +9,8 @@ import { Switch } from '@nextui-org/switch';
 
 import { ChallengeTypes } from '@/constants';
 import { logEventSimple } from '@/utils/gtag';
+import { getDurationString } from '@/utils/timestamp';
+import moment from 'moment';
 
 const defaultSelectedKeys = [ChallengeTypes.Run];
 
@@ -140,13 +142,17 @@ export default function CreateStep1({
 
       <DateRangePicker
         label="Challenge Duration"
-        className="my-4"
+        className="my-4 text-xs"
         granularity="day"
         value={duration}
         onChange={(newDuration) => {
           if (newDuration === null) return;
           setDuration(newDuration);
         }}
+        description={`Total duration: ${getDurationString(
+          moment.utc(duration.start.toAbsoluteString()).unix(),
+          moment.utc(duration.end.toAbsoluteString()).unix(),
+        )}`}
       />
 
       <Button

--- a/web/app/habit/stake/components/stakeContent.tsx
+++ b/web/app/habit/stake/components/stakeContent.tsx
@@ -161,11 +161,11 @@ export default function StakeChallenge() {
                 <div className="w-full justify-start p-6 py-2 text-start">
                   <div className="text-xl font-bold text-dark"> Goal </div>
                   <div className="text-sm text-primary"> {challenge.description} </div>
-                  {(challenge.minDistance || challenge.minTime) && (
+                  {challenge.minDistance || challenge.minTime ? (
                     <div className="mt-1 font-londrina text-sm text-gray-500">
                       {getChallengeRequirementDescription(challenge)}
                     </div>
-                  )}
+                  ) : null}
                 </div>
 
                 {/* checkIn description */}

--- a/web/src/utils/challenges.ts
+++ b/web/src/utils/challenges.ts
@@ -3,7 +3,7 @@ import { UserChallengeStatus } from '@/types';
 import { Challenge, UserStatus } from '@/types';
 import moment from 'moment';
 
-export function challengeToEmoji(type: ChallengeTypes) {
+export function challengeToEmoji(type: ChallengeTypes): string {
   switch (type) {
     case ChallengeTypes.Run:
       return '🏃';

--- a/web/src/utils/timestamp.ts
+++ b/web/src/utils/timestamp.ts
@@ -17,7 +17,7 @@ export function formatDuration(start: number, end: number): string {
   return `${formatTime(start)} - ${formatTime(end)}`;
 }
 
-export function getCountdownString(ending: number) {
+export function getCountdownString(ending: number, shorten: boolean = false) {
   var now = moment();
   var end = moment.unix(ending); // another date
   var duration = moment.duration(end.diff(now));
@@ -39,19 +39,19 @@ export function getCountdownString(ending: number) {
 
   // If > 14 days, only show days
   if (days > 14) {
-    return `${days} days`;
+    return `${days} ${shorten ? 'd' : 'days'}`;
   }
   // If > 0 days, show days and hours
   else if (days > 0) {
-    return `${days} days, ${hours} hours`;
+    return `${days} ${shorten ? 'd' : 'days'}, ${hours} ${shorten ? 'h' : 'hours'}`;
   }
 
   // If > 0 hours, show hours and minutes
   else if (hours > 0) {
-    return `${hours} hours, ${minutes} minutes`;
+    return `${hours} ${shorten ? 'h' : 'hours'}, ${minutes} ${shorten ? 'm' : 'minutes'}`;
   }
 
-  return `${minutes} minutes, ${seconds} seconds`;
+  return `${minutes} ${shorten ? 'm' : 'minutes'}`;
 }
 
 export function formatActivityTime(seconds: number): string {

--- a/web/src/utils/timestamp.ts
+++ b/web/src/utils/timestamp.ts
@@ -17,7 +17,7 @@ export function formatDuration(start: number, end: number): string {
   return `${formatTime(start)} - ${formatTime(end)}`;
 }
 
-export function getCountdownString(ending: number, shorten: boolean = false) {
+export function getCountdownString(ending: number, shorten = false) {
   var now = moment();
   var end = moment.unix(ending); // another date
   var duration = moment.duration(end.diff(now));
@@ -39,23 +39,45 @@ export function getCountdownString(ending: number, shorten: boolean = false) {
 
   // If > 14 days, only show days
   if (days > 14) {
-    return `${days} ${shorten ? 'd' : 'days'}`;
+    return `${days}${shorten ? 'd' : ' days'}`;
   }
   // If > 0 days, show days and hours
   else if (days > 0) {
-    return `${days} ${shorten ? 'd' : 'days'}, ${hours} ${shorten ? 'h' : 'hours'}`;
+    return `${days}${shorten ? 'd' : ' days'}, ${hours}${shorten ? 'h' : ' hours'}`;
   }
 
   // If > 0 hours, show hours and minutes
   else if (hours > 0) {
-    return `${hours} ${shorten ? 'h' : 'hours'}, ${minutes} ${shorten ? 'm' : 'minutes'}`;
+    return `${hours}${shorten ? 'h' : ' hours'}, ${minutes}${shorten ? 'm' : ' minutes'}`;
   }
 
-  return `${minutes} ${shorten ? 'm' : 'minutes'}`;
+  return `${minutes}${shorten ? 'm' : ' minutes'}`;
+}
+
+export function getDurationString(start: number, end: number): string {
+  const duration = moment.duration(end - start, 'second');
+  const days = duration.days();
+  const hours = duration.hours();
+  return `${days} days, ${hours} hours`;
 }
 
 export function formatActivityTime(seconds: number): string {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+export function getChallengePeriodHint(start: number, end: number): string {
+  // If it's not started yet, show "starts in "
+  if (start > moment().unix()) {
+    return `Starts in ${getCountdownString(start, true)}`;
+  }
+  // If it's already ended, show "nothing"
+  else if (end < moment().unix()) {
+    return '';
+  }
+  // If it's ongoing, show "ends in "
+  else {
+    return `${getCountdownString(end, true)} left`;
+  }
 }


### PR DESCRIPTION
* Resolves #215
* Resolves #211 by showing total duration (cannot simply set time to 23:59, it will be rounded to the next day on the calendar)
* Bug fix: when no requirement is set, the stake content UI shows "0"

* <img width="385" alt="Screenshot 2024-09-30 at 16 32 56" src="https://github.com/user-attachments/assets/b5e07f39-e30b-4740-a384-9dfd04b1bb6c"><img width="365" alt="Screenshot 2024-09-30 at 16 33 05" src="https://github.com/user-attachments/assets/c9b35950-3b3a-4918-8f4e-96524de7e545">

