### PR TITLE
fix: leaderboard check in delay (#210)

### DIFF
--- a/web/app/habit/checkin/components/ActivityCheckIn.tsx
+++ b/web/app/habit/checkin/components/ActivityCheckIn.tsx
@@ -183,10 +183,14 @@ export default function RunCheckIn({ challenge }: { challenge: ChallengeWithChec
         }
       }
       resetFields();
-      Promise.all([refetchAll()]).catch((error) => {
-        console.error('Error refetching data:', error);
-        // Optionally, handle the error more specifically here
-      });
+
+      // Add 2s delay before refetching
+      setTimeout(() => {
+        Promise.all([refetchAll()]).catch((error) => {
+          console.error('Error refetching data:', error);
+        });
+      }, 2000);
+
       handleOpenCheckinPopup();
     },
   );

--- a/web/app/habit/components/Leaderboard.tsx
+++ b/web/app/habit/components/Leaderboard.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from '@nextui-org/react';
 import { User } from '@/types';
 import { ChallengeTypes } from '@/constants';
+import { RotateCw } from 'lucide-react';
+import { useUserChallenges } from '@/providers/UserChallengesProvider';
 
 type LeaderboardProps = {
   userRankings: User[];
@@ -13,13 +15,23 @@ type LeaderboardProps = {
 };
 
 function Leaderboard({ userRankings, address, challenge }: LeaderboardProps) {
+  const { refetch } = useUserChallenges();
+
   const sortedUserRankings = [...userRankings].sort(
     (a, b) => Number(b.totalCheckIns) - Number(a.totalCheckIns),
   );
 
   return (
     <div className="mt-10 w-full max-w-md pb-12">
-      <div className="mb-5 text-xl text-dark">🏆 Leaderboard</div>
+      <div className="mb-5 flex items-center justify-between text-xl text-dark">
+        <span>🏆 Leaderboard</span>
+        <RotateCw
+          className="h-4 w-4 cursor-pointer"
+          onClick={() => {
+            refetch();
+          }}
+        />
+      </div>
       <Table aria-label="Leaderboard">
         <TableHeader>
           <TableColumn className="bg-white text-center">Rank</TableColumn>


### PR DESCRIPTION
fix #210

採用兩個解法：
1. 增加一個 reload button
2. wait 2s 之後再次 refetch

2 不完全可靠，因為 2s 只是我們估算的值，所以兩個解法都做

<img width="350" alt="截圖 2024-11-07 上午10 14 31" src="https://github.com/user-attachments/assets/a8e54c71-2345-41c6-9250-d73e2463e100">
